### PR TITLE
Allow using top-level dir as ROOT_FOLDER

### DIFF
--- a/build.js
+++ b/build.js
@@ -24,6 +24,11 @@ const generateTree = async (dir, options) => {
     let tree = [];
 
     const build = async (dir, parent) => {
+        // Skip output folder - this allows a user to use the top-level folder as ROOT_FOLDER.
+        if (dir === options.DIST_FOLDER) {
+            return
+        }
+
         let name = getFolderName(dir, options.ROOT_FOLDER, options.HOMEPAGE_NAME);
         let item = tree.find(x => x.dir === dir);
         if (!item) {


### PR DESCRIPTION
By ignoring the output folder (DIST_FOLDER), we allow a user to use the
top-level directory as the source folder (ROOT_FOLDER). This is useful
when the top-level README file provides introduction and getting-started
material and should be included in the generated files.

Closes #9