### PR TITLE
Support dots in folder names

### DIFF
--- a/build.js
+++ b/build.js
@@ -17,7 +17,7 @@ const {
 } = require('./utils.js');
 
 const getFolderName = (dir, root, homepage) => {
-    return dir === root ? homepage : path.parse(dir).name;
+    return dir === root ? homepage : path.parse(dir).base;
 };
 
 const generateTree = async (dir, options) => {


### PR DESCRIPTION
When using folder names like `example.com` the `.com` bit is parsed as a file extension even for folders and then you see just `example` in the sidebar.

If one wants different apps with their domain names or even worse - subdomains be in the sidebar, it wouldn't look great.

If we have `example.com.foo`, it would show `example.com` as only the last extension is removed.

So if we have `subdomain.example.com`, it would render `subdomain.example`.

With this change, it would get the entire filename of the folders regardless of dots. It would just strip the path to the folder based on directory separators.