### PR TITLE
Added PlantUML version 1.2020.17

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -128,8 +128,11 @@ const plantumlVersions = [{
     jar: 'plantuml-1.2019.9.jar'
 }, {
     version: '1.2020.07',
-    isLatest: true,
     jar: 'plantuml-1.2020.7.jar'
+}, {
+    version: '1.2020.17',
+    isLatest: true,
+    jar: 'plantuml.1.2020.17.jar'
 }];
 
 module.exports = {


### PR DESCRIPTION
- Added this version to the plantumlVersions list in utils.js
- Added plantuml.1.2020.17.jar (named with a period after "plantuml" rather than a hyphen, as this is what it is named on https://sourceforge.net/projects/plantuml/files/1.2020.17/ )