### PR TITLE
Add support for inlining diagram images as data URIs

### DIFF
--- a/build.js
+++ b/build.js
@@ -126,6 +126,17 @@ const generateImages = async (tree, options, onImageGenerated) => {
     return Promise.all(imagePromises);
 };
 
+const generateDataUri = async (item, pumlFile, options) => {
+    let imageData = await fs.promises.readFile(path.join(
+        '.',
+        `${options.DIST_FOLDER}`,
+        item.dir.replace(options.ROOT_FOLDER, ''),
+        path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`));
+
+    let base64 = imageData.toString('base64')
+    return `data:image/${options.DIAGRAM_FORMAT};base64,${base64}`;
+}
+
 const generateCompleteMD = async (tree, options) => {
     let filePromises = [];
 
@@ -156,7 +167,7 @@ const generateCompleteMD = async (tree, options) => {
             }
         };
         //add diagrams
-        const appendImages = () => {
+        const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
                 let diagramUrl = encodeURIPath(path.join(
@@ -166,6 +177,9 @@ const generateCompleteMD = async (tree, options) => {
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content, options);
+
+                if (options.GENERATE_LOCAL_IMAGES && options.USE_DATA_URIS)
+                    diagramUrl = await generateDataUri(item, pumlFile, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -178,11 +192,11 @@ const generateCompleteMD = async (tree, options) => {
         };
 
         if (options.DIAGRAMS_ON_TOP) {
-            appendImages();
+            await appendImages();
             appendText();
         } else {
             appendText();
-            appendImages();
+            await appendImages();
         }
     }
 
@@ -354,7 +368,7 @@ const generateMD = async (tree, options, onProgress) => {
             }
         };
         //add diagrams
-        const appendImages = () => {
+        const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
                 let diagramUrl = encodeURIPath(path.join(
@@ -363,6 +377,9 @@ const generateMD = async (tree, options, onProgress) => {
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content, options);
+
+                if (options.GENERATE_LOCAL_IMAGES && options.USE_DATA_URIS)
+                    diagramUrl = await generateDataUri(item, pumlFile, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -375,11 +392,11 @@ const generateMD = async (tree, options, onProgress) => {
         };
 
         if (options.DIAGRAMS_ON_TOP) {
-            appendImages();
+            await appendImages();
             appendText();
         } else {
             appendText();
-            appendImages();
+            await appendImages();
         }
 
         //write to disk
@@ -514,7 +531,7 @@ const generateWebMD = async (tree, options) => {
             }
         };
         //add diagrams
-        const appendImages = () => {
+        const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
 
@@ -524,6 +541,9 @@ const generateWebMD = async (tree, options) => {
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content, options);
+
+                if (options.GENERATE_LOCAL_IMAGES && options.USE_DATA_URIS)
+                    diagramUrl = await generateDataUri(item, pumlFile, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -538,11 +558,11 @@ const generateWebMD = async (tree, options) => {
         };
 
         if (options.DIAGRAMS_ON_TOP) {
-            appendImages();
+            await appendImages();
             appendText();
         } else {
             appendText();
-            appendImages();
+            await appendImages();
         }
 
         //write to disk

--- a/build.js
+++ b/build.js
@@ -165,7 +165,7 @@ const generateCompleteMD = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -231,7 +231,7 @@ const generateCompletePDF = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
 
@@ -362,7 +362,7 @@ const generateMD = async (tree, options, onProgress) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -423,7 +423,7 @@ const generatePDF = async (tree, options, onProgress) => {
                 MD += '\n\n';
                 let diagramUrl = encodeURIPath(path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`);
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
 
@@ -523,7 +523,7 @@ const generateWebMD = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -213,9 +213,10 @@ module.exports = async (currentConfiguration, conf, program) => {
         currentConfiguration.INCLUDE_BREADCRUMBS === undefined || currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined || program.config) {
         let defaults = [
             currentConfiguration.INCLUDE_BREADCRUMBS === undefined ? 'includeBreadcrumbs' : currentConfiguration.INCLUDE_BREADCRUMBS ? 'includeBreadcrumbs' : null,
-            currentConfiguration.GENERATE_LOCAL_IMAGES === undefined ? null : currentConfiguration.GENERATE_LOCAL_IMAGES ? 'generateLocalImages' : null,
             currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined ? null : currentConfiguration.INCLUDE_LINK_TO_DIAGRAM ? 'includeLinkToDiagram' : null,
-            currentConfiguration.DIAGRAMS_ON_TOP === undefined ? 'diagramsOnTop' : currentConfiguration.DIAGRAMS_ON_TOP ? 'diagramsOnTop' : null
+            currentConfiguration.DIAGRAMS_ON_TOP === undefined ? 'diagramsOnTop' : currentConfiguration.DIAGRAMS_ON_TOP ? 'diagramsOnTop' : null,
+            currentConfiguration.GENERATE_LOCAL_IMAGES === undefined ? null : currentConfiguration.GENERATE_LOCAL_IMAGES ? 'generateLocalImages' : null,
+            currentConfiguration.USE_DATA_URIS === undefined ? null : currentConfiguration.USE_DATA_URIS ? 'useDataURIs' : null
         ];
         let choices = [{
             name: 'Include breadcrumbs',
@@ -226,6 +227,9 @@ module.exports = async (currentConfiguration, conf, program) => {
         }, {
             name: 'Place diagrams before text',
             value: 'diagramsOnTop'
+        }, {
+            name: 'Inline images with data URIs. (Requires generateLocalImages to be on or non-latest plantuml)',
+            value: 'useDataURIs'
         }];
         if (ver.isLatest)
             choices.push({
@@ -245,8 +249,10 @@ module.exports = async (currentConfiguration, conf, program) => {
         conf.set('diagramsOnTop', !!responses.generate.find(x => x === 'diagramsOnTop'));
         if (ver.isLatest) {
             conf.set('generateLocalImages', !!responses.generate.find(x => x === 'generateLocalImages'));
+            conf.set('useDataURIs', !!responses.generate.find(x => x === 'useDataURIs'));
         } else {
             conf.set('generateLocalImages', true);
+            conf.set('useDataURIs', !!responses.generate.find(x => x === 'useDataURIs'));
         }
     }
 

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -259,4 +259,15 @@ module.exports = async (currentConfiguration, conf, program) => {
         });
         conf.set('charset', responses.charset);
     }
+
+    if (!currentConfiguration.DIAGRAM_FORMAT || program.config) {
+        responses = await inquirer.prompt({
+            type: 'list',
+            name: 'diagramFormat',
+            message: 'Select diagram format',
+            choices: ['svg', 'png'],
+            default: currentConfiguration.DIAGRAM_FORMAT || 'svg'
+        });
+        conf.set('diagramFormat', responses.diagramFormat);
+    }
 };

--- a/cli.help.js
+++ b/cli.help.js
@@ -49,5 +49,7 @@ ${chalk.cyan('Place diagrams before text')}
 Choose to place diagrams before or after the text.
 ${chalk.cyan('Diagram format')}
 Choose diagram format. Available format: png and svg.
+${chalk.cyan('Use data URIs')}
+Inline diagram images as data URIs. Requires local image generations and recommended diagram format is png.
     `);
 };

--- a/cli.help.js
+++ b/cli.help.js
@@ -47,5 +47,7 @@ ${chalk.cyan('Include breadcrumbs')}
 Shows the original folder hierarchy after each title.
 ${chalk.cyan('Place diagrams before text')}
 Choose to place diagrams before or after the text.
+${chalk.cyan('Diagram format')}
+Choose diagram format. Available format: png and svg.
     `);
 };

--- a/cli.js
+++ b/cli.js
@@ -43,14 +43,15 @@ const getOptions = conf => {
         INCLUDE_BREADCRUMBS: conf.get('includeBreadcrumbs'),
         INCLUDE_TABLE_OF_CONTENTS: conf.get('includeTableOfContents'),
         INCLUDE_LINK_TO_DIAGRAM: conf.get('includeLinkToDiagram'),
-        PDF_CSS: conf.get('pdfCss') || path.join(__dirname, 'pdf.css'),
+        PDF_CSS: conf.get('pdfCss') || path.join(__dirname, 'pdf.css'), // TODO: makes absolute path. Not portable.
         DIAGRAMS_ON_TOP: conf.get('diagramsOnTop'),
         CHARSET: conf.get('charset'),
         WEB_PORT: conf.get('webPort'),
         HAS_RUN: conf.get('hasRun'),
         MD_FILE_NAME: 'README',
         WEB_FILE_NAME: 'HOME',
-        DIAGRAM_FORMAT: conf.get('diagramFormat')
+        DIAGRAM_FORMAT: conf.get('diagramFormat'),
+        USE_DATA_URIS: conf.get('useDataURIs')
     }
 };
 

--- a/cli.js
+++ b/cli.js
@@ -50,7 +50,7 @@ const getOptions = conf => {
         HAS_RUN: conf.get('hasRun'),
         MD_FILE_NAME: 'README',
         WEB_FILE_NAME: 'HOME',
-        DIAGRAM_FORMAT: 'svg'
+        DIAGRAM_FORMAT: conf.get('diagramFormat')
     }
 };
 

--- a/cli.list.js
+++ b/cli.list.js
@@ -32,6 +32,7 @@ Generate diagram images locally: ${currentConfiguration.GENERATE_LOCAL_IMAGES !=
 Replace diagrams with a link: ${currentConfiguration.INCLUDE_LINK_TO_DIAGRAM !== undefined ? chalk.green(currentConfiguration.INCLUDE_LINK_TO_DIAGRAM) : chalk.red('not set')}
 Place diagrams before text: ${currentConfiguration.DIAGRAMS_ON_TOP !== undefined ? chalk.green(currentConfiguration.DIAGRAMS_ON_TOP) : chalk.red('not set')}
 Charset: ${currentConfiguration.CHARSET !== undefined ? chalk.green(currentConfiguration.CHARSET) : chalk.red('not set')}
+Diagram format: ${currentConfiguration.DIAGRAM_FORMAT !== undefined ? chalk.green(currentConfiguration.DIAGRAM_FORMAT) : chalk.red('not set')}
 `);
     return;
 };

--- a/cli.list.js
+++ b/cli.list.js
@@ -31,6 +31,8 @@ PlantUML version: ${currentConfiguration.PLANTUML_VERSION !== undefined ? chalk.
 Generate diagram images locally: ${currentConfiguration.GENERATE_LOCAL_IMAGES !== undefined ? chalk.green(currentConfiguration.GENERATE_LOCAL_IMAGES) : chalk.red('not set')}
 Replace diagrams with a link: ${currentConfiguration.INCLUDE_LINK_TO_DIAGRAM !== undefined ? chalk.green(currentConfiguration.INCLUDE_LINK_TO_DIAGRAM) : chalk.red('not set')}
 Place diagrams before text: ${currentConfiguration.DIAGRAMS_ON_TOP !== undefined ? chalk.green(currentConfiguration.DIAGRAMS_ON_TOP) : chalk.red('not set')}
+Inline diagram images: ${currentConfiguration.USE_DATA_URIS !== undefined ? chalk.green(currentConfiguration.USE_DATA_URIS) : chalk.red('not set')}
+
 Charset: ${currentConfiguration.CHARSET !== undefined ? chalk.green(currentConfiguration.CHARSET) : chalk.red('not set')}
 Diagram format: ${currentConfiguration.DIAGRAM_FORMAT !== undefined ? chalk.green(currentConfiguration.DIAGRAM_FORMAT) : chalk.red('not set')}
 `);

--- a/utils.js
+++ b/utils.js
@@ -116,7 +116,7 @@ const urlTextFrom = (s) => {
     }
 };
 
-const plantUmlServerUrl = content => `https://www.plantuml.com/plantuml/svg/0/${urlTextFrom(content)}`;
+const plantUmlServerUrl = (content, options) => `https://www.plantuml.com/plantuml/${options.DIAGRAM_FORMAT}/0/${urlTextFrom(content)}`;
 
 const clearConsole = () => {
     process.stdout.write('\x1b[2J');


### PR DESCRIPTION
* Add support to select diagram image format because browsers and markdown application are flaky with SVG
* Add support to inline diagram images as data URIs.
  * Provides a way to create self-contained Markdown and HTML files(if complete markdown file is converted to HTML)

To be solved:
* Is it feasible to inline automatically all markdown image references. Is it needed? 