### PR TITLE
evol: embed svg diagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 template/docs/
 template/.c4builder
+*.tgz

--- a/build.js
+++ b/build.js
@@ -167,13 +167,24 @@ const generateCompleteMD = async (tree, options) => {
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
 
-                let diagramImage = `![diagram](${diagramUrl})`;
-                let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
+                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
+                    let svgContent = fs.readFileSync(
+                        path.join(
+                            options.DIST_FOLDER,
+                            item.dir.replace(options.ROOT_FOLDER, ''),
+                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+                    ), "utf8")
+                    MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
+                }else{
 
-                if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
-                    MD += diagramImage;
-                else //link
-                    MD += diagramLink;
+                    let diagramImage = `![diagram](${diagramUrl})`;
+                    let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
+
+                    if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
+                        MD += diagramImage;
+                    else //link
+                        MD += diagramLink;
+                }
             }
         };
 
@@ -524,16 +535,30 @@ const generateWebMD = async (tree, options) => {
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
-
-                let diagramImage = `![diagram](${diagramUrl})`;
-                let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
-
-                if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
-                    MD += diagramImage;
-                else if (options.INCLUDE_LINK_TO_DIAGRAM && options.GENERATE_LOCAL_IMAGES)
-                    MD += diagramImage;
-                else //link
+                    
+                
+                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
+                    let svgContent = fs.readFileSync(
+                        path.join(
+                            options.DIST_FOLDER,
+                            item.dir.replace(options.ROOT_FOLDER, ''),
+                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+                            ), "utf8")
+                    MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
+                    
+                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
                     MD += diagramLink;
+                }else{
+
+                    let diagramImage = `![diagram](${diagramUrl})`;
+                    let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
+                    if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
+                        MD += diagramImage;
+                    else //link
+                        MD += diagramLink;
+                }
+                
             }
         };
 

--- a/build.js
+++ b/build.js
@@ -7,6 +7,8 @@ const fsextra = require('fs-extra');
 const docsifyTemplate = require('./docsify.template.js');
 const markdownpdf = require("md-to-pdf").mdToPdf;
 
+const http = require('http');
+
 const {
     encodeURIPath,
     makeDirectory,
@@ -21,6 +23,7 @@ const getFolderName = (dir, root, homepage) => {
 };
 
 const generateTree = async (dir, options) => {
+
     let tree = [];
 
     const build = async (dir, parent) => {
@@ -167,13 +170,24 @@ const generateCompleteMD = async (tree, options) => {
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
 
-                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
-                    let svgContent = fs.readFileSync(
-                        path.join(
-                            options.DIST_FOLDER,
-                            item.dir.replace(options.ROOT_FOLDER, ''),
-                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
-                    ), "utf8")
+                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg") {
+
+                    let svgContent = ""
+                    if (options.GENERATE_LOCAL_IMAGES){
+                        svgContent = fs.readFileSync(
+                            path.join(
+                                options.DIST_FOLDER,
+                                item.dir.replace(options.ROOT_FOLDER, ''),
+                                `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+                            ), "utf8")
+                    }else{
+                        (async function(){
+                            const response = await superagent.get(diagramUrl)
+                            svgContent = response.text
+                        })();
+
+                    }
+
                     MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
                 }else{
 
@@ -505,6 +519,29 @@ const generatePDF = async (tree, options, onProgress) => {
     return Promise.all(filePromises);
 };
 
+const httpGet =  async (url) => {
+        // return new pending promise
+        return new Promise((resolve, reject) => {
+            // select http or https module, depending on reqested url
+            const lib = url.startsWith('https') ? require('https') : require('http');
+            const request = lib.get(url, (response) => {
+                // handle http errors
+                if (response.statusCode < 200 || response.statusCode > 299) {
+                    reject(new Error('Failed to load page '+url+', status code: ' + response.statusCode));
+                }
+                // temporary data holder
+                const body = [];
+                // on every content chunk, push it to the data array
+                response.on('data', (chunk) => body.push(chunk));
+                // we are done, resolve promise with those joined chunks
+                response.on('end', () => resolve(body.join('')));
+            });
+            // handle connection errors of the request
+            request.on('error', (err) => reject(err))
+        })
+
+}
+
 const generateWebMD = async (tree, options) => {
     let filePromises = [];
     let docsifySideBar = '';
@@ -525,7 +562,7 @@ const generateWebMD = async (tree, options) => {
             }
         };
         //add diagrams
-        const appendImages = () => {
+        const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
 
@@ -538,17 +575,24 @@ const generateWebMD = async (tree, options) => {
                     
                 
                 if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
-                    let svgContent = fs.readFileSync(
-                        path.join(
-                            options.DIST_FOLDER,
-                            item.dir.replace(options.ROOT_FOLDER, ''),
-                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+
+                    let svgContent = ""
+                    if (options.GENERATE_LOCAL_IMAGES){
+                        svgContent = fs.readFileSync(
+                            path.join(
+                                options.DIST_FOLDER,
+                                item.dir.replace(options.ROOT_FOLDER, ''),
+                                `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
                             ), "utf8")
+                    }else{
+                        svgContent = await httpGet(diagramUrl)
+                    }
                     MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
-                    
+
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
                     let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
                     MD += diagramLink;
+
                 }else{
 
                     let diagramImage = `![diagram](${diagramUrl})`;
@@ -563,11 +607,11 @@ const generateWebMD = async (tree, options) => {
         };
 
         if (options.DIAGRAMS_ON_TOP) {
-            appendImages();
+            await appendImages();
             appendText();
         } else {
             appendText();
-            appendImages();
+            await appendImages();
         }
 
         //write to disk

--- a/build.js
+++ b/build.js
@@ -65,7 +65,7 @@ const generateTree = async (dir, options) => {
             const fileContents = await readFile(path.join(dir, pumlFile));
             item.pumlFiles.push({ dir: pumlFile, content: fileContents });
         }
-        item.sort(function (a, b) {
+        item.pumlFiles.sort(function (a, b) {
             return ('' + a.dir).localeCompare(b.dir);
         }) ;
 

--- a/build.js
+++ b/build.js
@@ -65,6 +65,9 @@ const generateTree = async (dir, options) => {
             const fileContents = await readFile(path.join(dir, pumlFile));
             item.pumlFiles.push({ dir: pumlFile, content: fileContents });
         }
+        item.sort(function (a, b) {
+            return ('' + a.dir).localeCompare(b.dir);
+        }) ;
 
         //copy all other files
         const otherFiles = files.filter(x => ['.md', '.puml'].indexOf(path.extname(x).toLowerCase()) === -1);

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -210,12 +210,16 @@ module.exports = async (currentConfiguration, conf, program) => {
     }
 
     if (currentConfiguration.GENERATE_LOCAL_IMAGES === undefined ||
-        currentConfiguration.INCLUDE_BREADCRUMBS === undefined || currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined || program.config) {
+        currentConfiguration.EMBED_SVG_DIAGRAM === undefined ||
+        currentConfiguration.INCLUDE_BREADCRUMBS === undefined || 
+        currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined || 
+        program.config) {
         let defaults = [
             currentConfiguration.INCLUDE_BREADCRUMBS === undefined ? 'includeBreadcrumbs' : currentConfiguration.INCLUDE_BREADCRUMBS ? 'includeBreadcrumbs' : null,
             currentConfiguration.GENERATE_LOCAL_IMAGES === undefined ? null : currentConfiguration.GENERATE_LOCAL_IMAGES ? 'generateLocalImages' : null,
             currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined ? null : currentConfiguration.INCLUDE_LINK_TO_DIAGRAM ? 'includeLinkToDiagram' : null,
-            currentConfiguration.DIAGRAMS_ON_TOP === undefined ? 'diagramsOnTop' : currentConfiguration.DIAGRAMS_ON_TOP ? 'diagramsOnTop' : null
+            currentConfiguration.DIAGRAMS_ON_TOP === undefined ? 'diagramsOnTop' : currentConfiguration.DIAGRAMS_ON_TOP ? 'diagramsOnTop' : null,
+            currentConfiguration.EMBED_SVG_DIAGRAM === undefined ? 'embedSvgDiagram' : currentConfiguration.EMBED_SVG_DIAGRAM ? 'embedSvgDiagram' : null
         ];
         let choices = [{
             name: 'Include breadcrumbs',
@@ -226,6 +230,9 @@ module.exports = async (currentConfiguration, conf, program) => {
         }, {
             name: 'Place diagrams before text',
             value: 'diagramsOnTop'
+        }, {
+            name: 'Embed SVG Diagram',
+            value: 'embedSvgDiagram'
         }];
         if (ver.isLatest)
             choices.push({
@@ -243,6 +250,7 @@ module.exports = async (currentConfiguration, conf, program) => {
         conf.set('includeBreadcrumbs', !!responses.generate.find(x => x === 'includeBreadcrumbs'));
         conf.set('includeLinkToDiagram', !!responses.generate.find(x => x === 'includeLinkToDiagram'));
         conf.set('diagramsOnTop', !!responses.generate.find(x => x === 'diagramsOnTop'));
+        conf.set('embedSvgDiagram', !!responses.generate.find(x => x === 'embedSvgDiagram'));
         if (ver.isLatest) {
             conf.set('generateLocalImages', !!responses.generate.find(x => x === 'generateLocalImages'));
         } else {

--- a/cli.js
+++ b/cli.js
@@ -33,6 +33,7 @@ const getOptions = conf => {
         GENERATE_COMPLETE_MD_FILE: conf.get('generateCompleteMD'),
         GENERATE_COMPLETE_PDF_FILE: conf.get('generateCompletePDF'),
         GENERATE_LOCAL_IMAGES: conf.get('generateLocalImages'),
+        EMBED_SVG_DIAGRAM: conf.get('embedSvgDiagram'),
         ROOT_FOLDER: conf.get('rootFolder'),
         DIST_FOLDER: conf.get('distFolder'),
         PROJECT_NAME: conf.get('projectName'),

--- a/cli.list.js
+++ b/cli.list.js
@@ -28,6 +28,7 @@ Include breadcrumbs: ${currentConfiguration.INCLUDE_BREADCRUMBS !== undefined ? 
 
 PlantUML version: ${currentConfiguration.PLANTUML_VERSION !== undefined ? chalk.green(currentConfiguration.PLANTUML_VERSION) : chalk.red('not set')}
 
+Embed SVG diagram : ${currentConfiguration.EMBED_SVG_DIAGRAM !== undefined ? chalk.green(currentConfiguration.EMBED_SVG_DIAGRAM) : chalk.red('not set')}
 Generate diagram images locally: ${currentConfiguration.GENERATE_LOCAL_IMAGES !== undefined ? chalk.green(currentConfiguration.GENERATE_LOCAL_IMAGES) : chalk.red('not set')}
 Replace diagrams with a link: ${currentConfiguration.INCLUDE_LINK_TO_DIAGRAM !== undefined ? chalk.green(currentConfiguration.INCLUDE_LINK_TO_DIAGRAM) : chalk.red('not set')}
 Place diagrams before text: ${currentConfiguration.DIAGRAMS_ON_TOP !== undefined ? chalk.green(currentConfiguration.DIAGRAMS_ON_TOP) : chalk.red('not set')}


### PR DESCRIPTION
Hello,

Please consider this pull request.

The purpose of the feature is to include the svg directly in the body of the markdown thus allowing the use of hyperlink in diagrams (diag level 1 -> diag leve2 ...).

To use it, just add the option embedSvgDiagram = true in the .c4builder