### PR TITLE
evol: allow overloading of the docsify template

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 const fsextra = require('fs-extra');
-const docsifyTemplate = require('./docsify.template.js');
+let docsifyTemplate = require('./docsify.template.js');
 const markdownpdf = require("md-to-pdf").mdToPdf;
 
 const {
@@ -553,6 +553,10 @@ const generateWebMD = async (tree, options) => {
         ), MD));
     }
 
+    if (options.DOCSIFY_TEMPLATE && options.DOCSIFY_TEMPLATE !== "" ){
+        docsifyTemplate = require(path.join(process.cwd(), options.DOCSIFY_TEMPLATE));
+    }
+    
     //docsify homepage
     filePromises.push(writeFile(path.join(
         options.DIST_FOLDER,

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -154,6 +154,14 @@ module.exports = async (currentConfiguration, conf, program) => {
 
             webOptions = await inquirer.prompt({
                 type: 'input',
+                name: 'docsifyTemplate',
+                message: 'Path to a specific Docsify template?',
+                default: ''
+            });
+            conf.set('docsifyTemplate', webOptions.docsifyTemplate);
+
+            webOptions = await inquirer.prompt({
+                type: 'input',
                 name: 'webPort',
                 message: 'Change the default serve port?',
                 default: currentConfiguration.WEB_PORT || '3000'

--- a/cli.js
+++ b/cli.js
@@ -39,6 +39,7 @@ const getOptions = conf => {
         REPO_NAME: conf.get('repoUrl'),
         HOMEPAGE_NAME: conf.get('homepageName'),
         WEB_THEME: conf.get('webTheme'),
+        DOCSIFY_TEMPLATE: conf.get('docsifyTemplate'),
         INCLUDE_NAVIGATION: conf.get('includeNavigation'),
         INCLUDE_BREADCRUMBS: conf.get('includeBreadcrumbs'),
         INCLUDE_TABLE_OF_CONTENTS: conf.get('includeTableOfContents'),

--- a/cli.list.js
+++ b/cli.list.js
@@ -21,7 +21,9 @@ Generate a single complete pdf file: ${currentConfiguration.GENERATE_COMPLETE_PD
             : ''}
 Generate website: ${currentConfiguration.GENERATE_WEBSITE !== undefined ? chalk.green(currentConfiguration.GENERATE_WEBSITE) : chalk.red('not set')}
     ${currentConfiguration.GENERATE_WEBSITE ?
-            `Website docsify theme: ${currentConfiguration.WEB_THEME ? chalk.green(currentConfiguration.WEB_THEME) : chalk.red('not set')}`
+            `Website docsify theme: ${currentConfiguration.WEB_THEME ? chalk.green(currentConfiguration.WEB_THEME) : chalk.red('not set')}
+            Path to a specific Docsify template: ${currentConfiguration.DOCSIFY_TEMPLATE ? chalk.green(currentConfiguration.DOCSIFY_TEMPLATE) : chalk.red('not set')}
+            `
             : ''}
 Repository Url: ${currentConfiguration.REPO_NAME ? chalk.green(currentConfiguration.REPO_NAME) : chalk.red('not set')}
 Include breadcrumbs: ${currentConfiguration.INCLUDE_BREADCRUMBS !== undefined ? chalk.green(currentConfiguration.INCLUDE_BREADCRUMBS) : chalk.red('not set')}


### PR DESCRIPTION
Hello,

Please consider this pull request.

The goal is to be able to overload the docsify index template: This allows for example to add docsify plugins.

