### PR TITLE
Feature/Include PlantUML diagrams at arbitrary positions in doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 template/docs/
 template/.c4builder
+
+#intellij
+.idea
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 template/docs/
 template/.c4builder
+*.tgz

--- a/build.js
+++ b/build.js
@@ -167,13 +167,24 @@ const generateCompleteMD = async (tree, options) => {
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
 
-                let diagramImage = `![diagram](${diagramUrl})`;
-                let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
+                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
+                    let svgContent = fs.readFileSync(
+                        path.join(
+                            options.DIST_FOLDER,
+                            item.dir.replace(options.ROOT_FOLDER, ''),
+                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+                    ), "utf8")
+                    MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
+                }else{
 
-                if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
-                    MD += diagramImage;
-                else //link
-                    MD += diagramLink;
+                    let diagramImage = `![diagram](${diagramUrl})`;
+                    let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
+
+                    if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
+                        MD += diagramImage;
+                    else //link
+                        MD += diagramLink;
+                }
             }
         };
 
@@ -524,16 +535,30 @@ const generateWebMD = async (tree, options) => {
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
-
-                let diagramImage = `![diagram](${diagramUrl})`;
-                let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
-
-                if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
-                    MD += diagramImage;
-                else if (options.INCLUDE_LINK_TO_DIAGRAM && options.GENERATE_LOCAL_IMAGES)
-                    MD += diagramImage;
-                else //link
+                    
+                
+                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
+                    let svgContent = fs.readFileSync(
+                        path.join(
+                            options.DIST_FOLDER,
+                            item.dir.replace(options.ROOT_FOLDER, ''),
+                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+                            ), "utf8")
+                    MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
+                    
+                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
                     MD += diagramLink;
+                }else{
+
+                    let diagramImage = `![diagram](${diagramUrl})`;
+                    let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
+                    if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
+                        MD += diagramImage;
+                    else //link
+                        MD += diagramLink;
+                }
+                
             }
         };
 

--- a/build.js
+++ b/build.js
@@ -185,6 +185,7 @@ const generateCompleteMD = async (tree, options) => {
                     else //link
                         MD += diagramLink;
                 }
+            }
         };
 
         if (options.DIAGRAMS_ON_TOP) {
@@ -554,7 +555,7 @@ const generateWebMD = async (tree, options) => {
                     let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
                     if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
                         MD += diagramImage;
-                else if (options.INCLUDE_LINK_TO_DIAGRAM && options.GENERATE_LOCAL_IMAGES)
+                    else if (options.INCLUDE_LINK_TO_DIAGRAM && options.GENERATE_LOCAL_IMAGES)
                     MD += diagramImage;
                     else //link
                         MD += diagramLink;

--- a/build.js
+++ b/build.js
@@ -153,62 +153,29 @@ const generateCompleteMD = async (tree, options) => {
         }
 
         //concatenate markdown files
-        const appendText = () => {
+        const appendText = async () => {
             for (const mdFile of item.mdFiles) {
                 MD += '\n\n';
                 MD += mdFile;
             }
+            MD = await replacePumlInMd(item.dir,MD,options);
         };
+
         //add diagrams
         const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
 
-                let diagramUrl = encodeURIPath(path.join(
-                    path.dirname(pumlFile.dir),
-                    path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
-                ));
-                if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
-
-
-                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
-
-                    let svgContent = ""
-                    if (options.GENERATE_LOCAL_IMAGES){
-                        svgContent = fs.readFileSync(
-                            path.join(
-                                options.DIST_FOLDER,
-                                item.dir.replace(options.ROOT_FOLDER, ''),
-                                `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
-                            ), "utf8")
-                    }else{
-                        svgContent = await httpGet(diagramUrl)
-                    }
-                    MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
-
-                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
-                    let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
-                    MD += diagramLink;
-
-                }else{
-
-                    let diagramImage = `![diagram](${diagramUrl})`;
-                    let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
-                    if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
-                        MD += diagramImage;
-                    else //link
-                        MD += diagramLink;
-                }
+                MD += await processPuml(path.dirname(pumlFile.dir),path.parse(pumlFile.dir).name,pumlFile.content, options);
 
             }
         };
 
         if (options.DIAGRAMS_ON_TOP) {
             await appendImages();
-            appendText();
+            await appendText();
         } else {
-            appendText();
+            await appendText();
             await appendImages();
         }
     }
@@ -243,35 +210,30 @@ const generateCompletePDF = async (tree, options) => {
         }
 
         //concatenate markdown files
-        const appendText = () => {
+        const appendText = async () => {
             for (const mdFile of item.mdFiles) {
                 MD += '\n\n';
                 MD += mdFile;
             }
+            MD = await replacePumlInMd(item.dir,MD,options);
         };
+
         //add diagrams
-        const appendImages = () => {
+        const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
-                let diagramUrl = encodeURIPath(path.join(
-                    item.dir.replace(options.ROOT_FOLDER, ''),
-                    path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
-                ));
-                if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
-                let diagramImage = `![diagram](${diagramUrl})`;
+                MD += await processPuml(path.dirname(pumlFile.dir),path.parse(pumlFile.dir).name,pumlFile.content, options);
 
-                MD += diagramImage;
             }
         };
 
         if (options.DIAGRAMS_ON_TOP) {
-            appendImages();
-            appendText();
+            await appendImages();
+            await appendText();
         } else {
-            appendText();
-            appendImages();
+            await appendText();
+            await appendImages();
         }
     }
 
@@ -374,62 +336,29 @@ const generateMD = async (tree, options, onProgress) => {
             MD += `\n\n---`;
 
         //concatenate markdown files
-        const appendText = () => {
+        const appendText = async () => {
             for (const mdFile of item.mdFiles) {
                 MD += '\n\n';
                 MD += mdFile;
             }
+            MD = await replacePumlInMd(item.dir,MD,options);
         };
+
         //add diagrams
         const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
 
-                let diagramUrl = encodeURIPath(path.join(
-                    path.dirname(pumlFile.dir),
-                    path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
-                ));
-                if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
-
-
-                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
-
-                    let svgContent = ""
-                    if (options.GENERATE_LOCAL_IMAGES){
-                        svgContent = fs.readFileSync(
-                            path.join(
-                                options.DIST_FOLDER,
-                                item.dir.replace(options.ROOT_FOLDER, ''),
-                                `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
-                            ), "utf8")
-                    }else{
-                        svgContent = await httpGet(diagramUrl)
-                    }
-                    MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
-
-                    diagramUrl = plantUmlServerUrl(pumlFile.content,options);
-                    let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
-                    MD += diagramLink;
-
-                }else{
-
-                    let diagramImage = `![diagram](${diagramUrl})`;
-                    let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
-                    if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
-                        MD += diagramImage;
-                    else //link
-                        MD += diagramLink;
-                }
+                MD += await processPuml(path.dirname(pumlFile.dir),path.parse(pumlFile.dir).name,pumlFile.content, options);
 
             }
         };
 
         if (options.DIAGRAMS_ON_TOP) {
             await appendImages();
-            appendText();
+            await appendText();
         } else {
-            appendText();
+            await appendText();
             await appendImages();
         }
 
@@ -462,32 +391,30 @@ const generatePDF = async (tree, options, onProgress) => {
             MD += `\n\n\`${item.dir.replace(options.ROOT_FOLDER, '')}\``;
 
         //concatenate markdown files
-        const appendText = () => {
+        const appendText = async () => {
             for (const mdFile of item.mdFiles) {
                 MD += '\n\n';
                 MD += mdFile;
             }
+            MD = await replacePumlInMd(item.dir,MD,options);
         };
+
         //add diagrams
-        const appendImages = () => {
+        const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
-                let diagramUrl = encodeURIPath(path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`);
-                if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
-                let diagramImage = `![diagram](${diagramUrl})`;
+                MD += await processPuml(path.dirname(pumlFile.dir),path.parse(pumlFile.dir).name,pumlFile.content, options);
 
-                MD += diagramImage;
             }
         };
 
         if (options.DIAGRAMS_ON_TOP) {
-            appendImages();
-            appendText();
+            await appendImages();
+            await appendText();
         } else {
-            appendText();
-            appendImages();
+            await appendText();
+            await appendImages();
         }
 
         totalCount++;
@@ -568,6 +495,78 @@ const httpGet =  async (url) => {
 
 }
 
+const processPuml = async (currentPath, pumlFileName, pumlFileContent , options) => {
+    let diagramUrl = encodeURIPath(path.join(
+        currentPath,
+        pumlFileName + `.${options.DIAGRAM_FORMAT}`
+    ));
+
+    if (!options.GENERATE_LOCAL_IMAGES) {
+        diagramUrl = plantUmlServerUrl(pumlFileContent, options);
+    }
+    let result = "";
+    if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
+
+        let svgContent = ""
+        if (options.GENERATE_LOCAL_IMAGES){
+            svgContent = fs.readFileSync(
+                path.join(
+                    currentPath,
+                    `${pumlFileName}.${options.DIAGRAM_FORMAT}`
+                ), "utf8")
+            console.log(path.join(
+                currentPath,
+                `${pumlFileName}.${options.DIAGRAM_FORMAT}`
+            ));
+        }else{
+            svgContent = await httpGet(diagramUrl)
+        }
+        result += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
+
+        diagramUrl = plantUmlServerUrl(pumlFileContent,options);
+        let diagramLink = `[Download ${pumlFileName} diagram](${diagramUrl} ':ignore')`;
+        result += diagramLink;
+
+    }else{
+
+        let diagramImage = `![diagram](${diagramUrl})`;
+        let diagramLink = `[Go to ${pumlFileName} diagram](${diagramUrl})`;
+        if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
+            result += diagramImage;
+        else if (options.INCLUDE_LINK_TO_DIAGRAM && options.GENERATE_LOCAL_IMAGES)
+            result += diagramImage;
+        else //link
+            result += diagramLink;
+    }
+
+    return result ;
+}
+
+const replacePumlInMd = async (currentPath, content,options) => {
+    const promises = [];
+    let regex = /(!\[.*?\]\()(_.+\.puml)(.*)(\))/g
+    content.replace(regex, function(whole, a, b, c,d) {
+
+        const replaceAsync =   async function(whole, a, b, c,d) {
+            let pumlFileName = b.trim();
+            let result = "";
+            let pumlFileContent = fs.readFileSync(
+                path.join(
+                    currentPath,pumlFileName
+                ), "utf8")
+
+            result = await processPuml(currentPath,pumlFileName,pumlFileContent, options);
+
+            return result;
+        }
+        promises.push(replaceAsync(whole, a, b, c));
+
+    });
+
+    const data = await Promise.all(promises);
+    return content.replace(regex, () => data.shift());
+}
+
 const generateWebMD = async (tree, options) => {
     let filePromises = [];
     let docsifySideBar = '';
@@ -581,55 +580,19 @@ const generateWebMD = async (tree, options) => {
         let MD = `# ${name}`;
 
         //concatenate markdown files
-        const appendText = () => {
+        const appendText = async () => {
             for (const mdFile of item.mdFiles) {
                 MD += '\n\n';
                 MD += mdFile;
             }
+            MD = await replacePumlInMd(item.dir,MD,options);
         };
         //add diagrams
         const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
 
-                let diagramUrl = encodeURIPath(path.join(
-                    path.dirname(pumlFile.dir),
-                    path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
-                ));
-                if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
-
-
-                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
-
-                    let svgContent = ""
-                    if (options.GENERATE_LOCAL_IMAGES){
-                        svgContent = fs.readFileSync(
-                            path.join(
-                                options.DIST_FOLDER,
-                                item.dir.replace(options.ROOT_FOLDER, ''),
-                                `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
-                            ), "utf8")
-                    }else{
-                        svgContent = await httpGet(diagramUrl)
-                    }
-                    MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
-
-                    diagramUrl = plantUmlServerUrl(pumlFile.content,options);
-                    let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
-                    MD += diagramLink;
-
-                }else{
-
-                    let diagramImage = `![diagram](${diagramUrl})`;
-                    let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
-                    if (!options.INCLUDE_LINK_TO_DIAGRAM) //img
-                        MD += diagramImage;
-                    else if (options.INCLUDE_LINK_TO_DIAGRAM && options.GENERATE_LOCAL_IMAGES)
-                    MD += diagramImage;
-                    else //link
-                        MD += diagramLink;
-                }
+                MD += await processPuml(path.dirname(pumlFile.dir),path.parse(pumlFile.dir).name,pumlFile.content, options);
 
             }
         };

--- a/build.js
+++ b/build.js
@@ -165,7 +165,7 @@ const generateCompleteMD = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -231,7 +231,7 @@ const generateCompletePDF = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
 
@@ -362,7 +362,7 @@ const generateMD = async (tree, options, onProgress) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -423,7 +423,7 @@ const generatePDF = async (tree, options, onProgress) => {
                 MD += '\n\n';
                 let diagramUrl = encodeURIPath(path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`);
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
 
@@ -523,7 +523,7 @@ const generateWebMD = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;

--- a/build.js
+++ b/build.js
@@ -68,7 +68,8 @@ const generateTree = async (dir, options) => {
         }) ;
 
         //copy all other files
-        const otherFiles = files.filter(x => ['.md', '.puml'].indexOf(path.extname(x).toLowerCase()) === -1);
+        files = fs.readdirSync(dir)
+        const otherFiles = files.filter(x => x.charAt(0) === '_' || ['.md', '.puml'].indexOf(path.extname(x).toLowerCase()) === -1);
         for (const otherFile of otherFiles) {
             if (fs.statSync(path.join(dir, otherFile)).isDirectory())
                 continue;
@@ -599,9 +600,9 @@ const generateWebMD = async (tree, options) => {
 
         if (options.DIAGRAMS_ON_TOP) {
             await appendImages();
-            appendText();
+            await appendText();
         } else {
-            appendText();
+            await appendText();
             await appendImages();
         }
 

--- a/build.js
+++ b/build.js
@@ -7,6 +7,8 @@ const fsextra = require('fs-extra');
 const docsifyTemplate = require('./docsify.template.js');
 const markdownpdf = require("md-to-pdf").mdToPdf;
 
+const http = require('http');
+
 const {
     encodeURIPath,
     makeDirectory,
@@ -21,6 +23,7 @@ const getFolderName = (dir, root, homepage) => {
 };
 
 const generateTree = async (dir, options) => {
+
     let tree = [];
 
     const build = async (dir, parent) => {
@@ -167,13 +170,24 @@ const generateCompleteMD = async (tree, options) => {
                 if (!options.GENERATE_LOCAL_IMAGES)
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
 
-                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
-                    let svgContent = fs.readFileSync(
-                        path.join(
-                            options.DIST_FOLDER,
-                            item.dir.replace(options.ROOT_FOLDER, ''),
-                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
-                    ), "utf8")
+                if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg") {
+
+                    let svgContent = ""
+                    if (options.GENERATE_LOCAL_IMAGES){
+                        svgContent = fs.readFileSync(
+                            path.join(
+                                options.DIST_FOLDER,
+                                item.dir.replace(options.ROOT_FOLDER, ''),
+                                `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+                            ), "utf8")
+                    }else{
+                        (async function(){
+                            const response = await superagent.get(diagramUrl)
+                            svgContent = response.text
+                        })();
+
+                    }
+
                     MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
                 }else{
 
@@ -505,6 +519,29 @@ const generatePDF = async (tree, options, onProgress) => {
     return Promise.all(filePromises);
 };
 
+const httpGet =  async (url) => {
+        // return new pending promise
+        return new Promise((resolve, reject) => {
+            // select http or https module, depending on reqested url
+            const lib = url.startsWith('https') ? require('https') : require('http');
+            const request = lib.get(url, (response) => {
+                // handle http errors
+                if (response.statusCode < 200 || response.statusCode > 299) {
+                    reject(new Error('Failed to load page '+url+', status code: ' + response.statusCode));
+                }
+                // temporary data holder
+                const body = [];
+                // on every content chunk, push it to the data array
+                response.on('data', (chunk) => body.push(chunk));
+                // we are done, resolve promise with those joined chunks
+                response.on('end', () => resolve(body.join('')));
+            });
+            // handle connection errors of the request
+            request.on('error', (err) => reject(err))
+        })
+
+}
+
 const generateWebMD = async (tree, options) => {
     let filePromises = [];
     let docsifySideBar = '';
@@ -525,7 +562,7 @@ const generateWebMD = async (tree, options) => {
             }
         };
         //add diagrams
-        const appendImages = () => {
+        const appendImages = async () => {
             for (const pumlFile of item.pumlFiles) {
                 MD += '\n\n';
 
@@ -538,17 +575,24 @@ const generateWebMD = async (tree, options) => {
                     
                 
                 if (options.EMBED_SVG_DIAGRAM && options.DIAGRAM_FORMAT == "svg"){
-                    let svgContent = fs.readFileSync(
-                        path.join(
-                            options.DIST_FOLDER,
-                            item.dir.replace(options.ROOT_FOLDER, ''),
-                            `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
+
+                    let svgContent = ""
+                    if (options.GENERATE_LOCAL_IMAGES){
+                        svgContent = fs.readFileSync(
+                            path.join(
+                                options.DIST_FOLDER,
+                                item.dir.replace(options.ROOT_FOLDER, ''),
+                                `${path.parse(pumlFile.dir).name}.${options.DIAGRAM_FORMAT}`
                             ), "utf8")
+                    }else{
+                        svgContent = await httpGet(diagramUrl)
+                    }
                     MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
-                    
+
                     diagramUrl = plantUmlServerUrl(pumlFile.content);
                     let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
                     MD += diagramLink;
+
                 }else{
 
                     let diagramImage = `![diagram](${diagramUrl})`;
@@ -563,11 +607,11 @@ const generateWebMD = async (tree, options) => {
         };
 
         if (options.DIAGRAMS_ON_TOP) {
-            appendImages();
+            await appendImages();
             appendText();
         } else {
             appendText();
-            appendImages();
+            await appendImages();
         }
 
         //write to disk

--- a/build.js
+++ b/build.js
@@ -7,8 +7,6 @@ const fsextra = require('fs-extra');
 let docsifyTemplate = require('./docsify.template.js');
 const markdownpdf = require("md-to-pdf").mdToPdf;
 
-const http = require('http');
-
 const {
     encodeURIPath,
     makeDirectory,
@@ -65,7 +63,7 @@ const generateTree = async (dir, options) => {
             const fileContents = await readFile(path.join(dir, pumlFile));
             item.pumlFiles.push({ dir: pumlFile, content: fileContents });
         }
-        item.sort(function (a, b) {
+        item.pumlFiles.sort(function (a, b) {
             return ('' + a.dir).localeCompare(b.dir);
         }) ;
 

--- a/build.js
+++ b/build.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 const fsextra = require('fs-extra');
-const docsifyTemplate = require('./docsify.template.js');
+let docsifyTemplate = require('./docsify.template.js');
 const markdownpdf = require("md-to-pdf").mdToPdf;
 
 const {
@@ -553,6 +553,10 @@ const generateWebMD = async (tree, options) => {
         ), MD));
     }
 
+    if (options.DOCSIFY_TEMPLATE && options.DOCSIFY_TEMPLATE !== "" ){
+        docsifyTemplate = require(path.join(process.cwd(), options.DOCSIFY_TEMPLATE));
+    }
+    
     //docsify homepage
     filePromises.push(writeFile(path.join(
         options.DIST_FOLDER,

--- a/build.js
+++ b/build.js
@@ -65,6 +65,9 @@ const generateTree = async (dir, options) => {
             const fileContents = await readFile(path.join(dir, pumlFile));
             item.pumlFiles.push({ dir: pumlFile, content: fileContents });
         }
+        item.sort(function (a, b) {
+            return ('' + a.dir).localeCompare(b.dir);
+        }) ;
 
         //copy all other files
         const otherFiles = files.filter(x => ['.md', '.puml'].indexOf(path.extname(x).toLowerCase()) === -1);

--- a/build.js
+++ b/build.js
@@ -186,7 +186,7 @@ const generateCompleteMD = async (tree, options) => {
                     }
                     MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
 
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content, options);
                     let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
                     MD += diagramLink;
 
@@ -407,7 +407,7 @@ const generateMD = async (tree, options, onProgress) => {
                     }
                     MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
 
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content,options);
                     let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
                     MD += diagramLink;
 
@@ -614,7 +614,7 @@ const generateWebMD = async (tree, options) => {
                     }
                     MD += "\n\n<div>"+svgContent.replace(/(<!--.*?-->)|(<!--[\w\W\n\s]+?-->)/gm, "")+"</div>\n\n"
 
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(pumlFile.content,options);
                     let diagramLink = `[Download ${path.parse(pumlFile.dir).name} diagram](${diagramUrl} ':ignore')`;
                     MD += diagramLink;
 

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -154,6 +154,14 @@ module.exports = async (currentConfiguration, conf, program) => {
 
             webOptions = await inquirer.prompt({
                 type: 'input',
+                name: 'docsifyTemplate',
+                message: 'Path to a specific Docsify template?',
+                default: ''
+            });
+            conf.set('docsifyTemplate', webOptions.docsifyTemplate);
+
+            webOptions = await inquirer.prompt({
+                type: 'input',
                 name: 'webPort',
                 message: 'Change the default serve port?',
                 default: currentConfiguration.WEB_PORT || '3000'

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -263,10 +263,10 @@ module.exports = async (currentConfiguration, conf, program) => {
     if (!currentConfiguration.SERVER_BASE_ADDRESS || program.config) {
         responses = await inquirer.prompt({
             type: 'input',
-            name: 'serverBaseAddress',
+            name: 'plantUmlServerBaseAddress',
             message: 'Change server base address',
             default: currentConfiguration.SERVER_BASE_ADDRESS || 'https://www.plantuml.com/plantuml/'
         });
-        conf.set('serverBaseAddress', responses.serverBaseAddress);
+        conf.set('plantUmlServerBaseAddress', responses.plantUmlServerBaseAddress);
     }
 };

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -259,4 +259,14 @@ module.exports = async (currentConfiguration, conf, program) => {
         });
         conf.set('charset', responses.charset);
     }
+
+    if (!currentConfiguration.SERVER_BASE_ADDRESS || program.config) {
+        responses = await inquirer.prompt({
+            type: 'input',
+            name: 'serverBaseAddress',
+            message: 'Change server base address',
+            default: currentConfiguration.SERVER_BASE_ADDRESS || 'https://www.plantuml.com/plantuml/'
+        });
+        conf.set('serverBaseAddress', responses.serverBaseAddress);
+    }
 };

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -210,12 +210,16 @@ module.exports = async (currentConfiguration, conf, program) => {
     }
 
     if (currentConfiguration.GENERATE_LOCAL_IMAGES === undefined ||
-        currentConfiguration.INCLUDE_BREADCRUMBS === undefined || currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined || program.config) {
+        currentConfiguration.EMBED_SVG_DIAGRAM === undefined ||
+        currentConfiguration.INCLUDE_BREADCRUMBS === undefined || 
+        currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined || 
+        program.config) {
         let defaults = [
             currentConfiguration.INCLUDE_BREADCRUMBS === undefined ? 'includeBreadcrumbs' : currentConfiguration.INCLUDE_BREADCRUMBS ? 'includeBreadcrumbs' : null,
             currentConfiguration.GENERATE_LOCAL_IMAGES === undefined ? null : currentConfiguration.GENERATE_LOCAL_IMAGES ? 'generateLocalImages' : null,
             currentConfiguration.INCLUDE_LINK_TO_DIAGRAM === undefined ? null : currentConfiguration.INCLUDE_LINK_TO_DIAGRAM ? 'includeLinkToDiagram' : null,
-            currentConfiguration.DIAGRAMS_ON_TOP === undefined ? 'diagramsOnTop' : currentConfiguration.DIAGRAMS_ON_TOP ? 'diagramsOnTop' : null
+            currentConfiguration.DIAGRAMS_ON_TOP === undefined ? 'diagramsOnTop' : currentConfiguration.DIAGRAMS_ON_TOP ? 'diagramsOnTop' : null,
+            currentConfiguration.EMBED_SVG_DIAGRAM === undefined ? 'embedSvgDiagram' : currentConfiguration.EMBED_SVG_DIAGRAM ? 'embedSvgDiagram' : null
         ];
         let choices = [{
             name: 'Include breadcrumbs',
@@ -226,6 +230,9 @@ module.exports = async (currentConfiguration, conf, program) => {
         }, {
             name: 'Place diagrams before text',
             value: 'diagramsOnTop'
+        }, {
+            name: 'Embed SVG Diagram',
+            value: 'embedSvgDiagram'
         }];
         if (ver.isLatest)
             choices.push({
@@ -243,6 +250,7 @@ module.exports = async (currentConfiguration, conf, program) => {
         conf.set('includeBreadcrumbs', !!responses.generate.find(x => x === 'includeBreadcrumbs'));
         conf.set('includeLinkToDiagram', !!responses.generate.find(x => x === 'includeLinkToDiagram'));
         conf.set('diagramsOnTop', !!responses.generate.find(x => x === 'diagramsOnTop'));
+        conf.set('embedSvgDiagram', !!responses.generate.find(x => x === 'embedSvgDiagram'));
         if (ver.isLatest) {
             conf.set('generateLocalImages', !!responses.generate.find(x => x === 'generateLocalImages'));
         } else {

--- a/cli.help.js
+++ b/cli.help.js
@@ -47,5 +47,7 @@ ${chalk.cyan('Include breadcrumbs')}
 Shows the original folder hierarchy after each title.
 ${chalk.cyan('Place diagrams before text')}
 Choose to place diagrams before or after the text.
+${chalk.cyan('Use external PlantUML server')}
+Change the PlantUML server.
     `);
 };

--- a/cli.js
+++ b/cli.js
@@ -39,6 +39,7 @@ const getOptions = conf => {
         REPO_NAME: conf.get('repoUrl'),
         HOMEPAGE_NAME: conf.get('homepageName'),
         WEB_THEME: conf.get('webTheme'),
+        DOCSIFY_TEMPLATE: conf.get('docsifyTemplate'),
         INCLUDE_NAVIGATION: conf.get('includeNavigation'),
         INCLUDE_BREADCRUMBS: conf.get('includeBreadcrumbs'),
         INCLUDE_TABLE_OF_CONTENTS: conf.get('includeTableOfContents'),

--- a/cli.js
+++ b/cli.js
@@ -51,7 +51,7 @@ const getOptions = conf => {
         MD_FILE_NAME: 'README',
         WEB_FILE_NAME: 'HOME',
         DIAGRAM_FORMAT: 'svg',
-        SERVER_BASE_ADDRESS: conf.get('serverBaseAddress')
+        SERVER_BASE_ADDRESS: conf.get('plantUmlServerBaseAddress')
     }
 };
 

--- a/cli.js
+++ b/cli.js
@@ -33,6 +33,7 @@ const getOptions = conf => {
         GENERATE_COMPLETE_MD_FILE: conf.get('generateCompleteMD'),
         GENERATE_COMPLETE_PDF_FILE: conf.get('generateCompletePDF'),
         GENERATE_LOCAL_IMAGES: conf.get('generateLocalImages'),
+        EMBED_SVG_DIAGRAM: conf.get('embedSvgDiagram'),
         ROOT_FOLDER: conf.get('rootFolder'),
         DIST_FOLDER: conf.get('distFolder'),
         PROJECT_NAME: conf.get('projectName'),

--- a/cli.js
+++ b/cli.js
@@ -50,7 +50,8 @@ const getOptions = conf => {
         HAS_RUN: conf.get('hasRun'),
         MD_FILE_NAME: 'README',
         WEB_FILE_NAME: 'HOME',
-        DIAGRAM_FORMAT: 'svg'
+        DIAGRAM_FORMAT: 'svg',
+        SERVER_BASE_ADDRESS: conf.get('serverBaseAddress')
     }
 };
 

--- a/cli.list.js
+++ b/cli.list.js
@@ -21,7 +21,9 @@ Generate a single complete pdf file: ${currentConfiguration.GENERATE_COMPLETE_PD
             : ''}
 Generate website: ${currentConfiguration.GENERATE_WEBSITE !== undefined ? chalk.green(currentConfiguration.GENERATE_WEBSITE) : chalk.red('not set')}
     ${currentConfiguration.GENERATE_WEBSITE ?
-            `Website docsify theme: ${currentConfiguration.WEB_THEME ? chalk.green(currentConfiguration.WEB_THEME) : chalk.red('not set')}`
+            `Website docsify theme: ${currentConfiguration.WEB_THEME ? chalk.green(currentConfiguration.WEB_THEME) : chalk.red('not set')}
+            Path to a specific Docsify template: ${currentConfiguration.DOCSIFY_TEMPLATE ? chalk.green(currentConfiguration.DOCSIFY_TEMPLATE) : chalk.red('not set')}
+            `
             : ''}
 Repository Url: ${currentConfiguration.REPO_NAME ? chalk.green(currentConfiguration.REPO_NAME) : chalk.red('not set')}
 Include breadcrumbs: ${currentConfiguration.INCLUDE_BREADCRUMBS !== undefined ? chalk.green(currentConfiguration.INCLUDE_BREADCRUMBS) : chalk.red('not set')}

--- a/cli.list.js
+++ b/cli.list.js
@@ -28,6 +28,7 @@ Include breadcrumbs: ${currentConfiguration.INCLUDE_BREADCRUMBS !== undefined ? 
 
 PlantUML version: ${currentConfiguration.PLANTUML_VERSION !== undefined ? chalk.green(currentConfiguration.PLANTUML_VERSION) : chalk.red('not set')}
 
+Embed SVG diagram : ${currentConfiguration.EMBED_SVG_DIAGRAM !== undefined ? chalk.green(currentConfiguration.EMBED_SVG_DIAGRAM) : chalk.red('not set')}
 Generate diagram images locally: ${currentConfiguration.GENERATE_LOCAL_IMAGES !== undefined ? chalk.green(currentConfiguration.GENERATE_LOCAL_IMAGES) : chalk.red('not set')}
 Replace diagrams with a link: ${currentConfiguration.INCLUDE_LINK_TO_DIAGRAM !== undefined ? chalk.green(currentConfiguration.INCLUDE_LINK_TO_DIAGRAM) : chalk.red('not set')}
 Place diagrams before text: ${currentConfiguration.DIAGRAMS_ON_TOP !== undefined ? chalk.green(currentConfiguration.DIAGRAMS_ON_TOP) : chalk.red('not set')}

--- a/cli.list.js
+++ b/cli.list.js
@@ -32,6 +32,7 @@ Generate diagram images locally: ${currentConfiguration.GENERATE_LOCAL_IMAGES !=
 Replace diagrams with a link: ${currentConfiguration.INCLUDE_LINK_TO_DIAGRAM !== undefined ? chalk.green(currentConfiguration.INCLUDE_LINK_TO_DIAGRAM) : chalk.red('not set')}
 Place diagrams before text: ${currentConfiguration.DIAGRAMS_ON_TOP !== undefined ? chalk.green(currentConfiguration.DIAGRAMS_ON_TOP) : chalk.red('not set')}
 Charset: ${currentConfiguration.CHARSET !== undefined ? chalk.green(currentConfiguration.CHARSET) : chalk.red('not set')}
+Server base address: ${currentConfiguration.SERVER_BASE_ADDRESS !== undefined ? chalk.green(currentConfiguration.SERVER_BASE_ADDRESS) : chalk.red('not set')}
 `);
     return;
 };

--- a/cli.list.js
+++ b/cli.list.js
@@ -32,7 +32,7 @@ Generate diagram images locally: ${currentConfiguration.GENERATE_LOCAL_IMAGES !=
 Replace diagrams with a link: ${currentConfiguration.INCLUDE_LINK_TO_DIAGRAM !== undefined ? chalk.green(currentConfiguration.INCLUDE_LINK_TO_DIAGRAM) : chalk.red('not set')}
 Place diagrams before text: ${currentConfiguration.DIAGRAMS_ON_TOP !== undefined ? chalk.green(currentConfiguration.DIAGRAMS_ON_TOP) : chalk.red('not set')}
 Charset: ${currentConfiguration.CHARSET !== undefined ? chalk.green(currentConfiguration.CHARSET) : chalk.red('not set')}
-Server base address: ${currentConfiguration.SERVER_BASE_ADDRESS !== undefined ? chalk.green(currentConfiguration.SERVER_BASE_ADDRESS) : chalk.red('not set')}
+PlantUml server base address: ${currentConfiguration.SERVER_BASE_ADDRESS !== undefined ? chalk.green(currentConfiguration.SERVER_BASE_ADDRESS) : chalk.red('not set')}
 `);
     return;
 };

--- a/utils.js
+++ b/utils.js
@@ -116,7 +116,7 @@ const urlTextFrom = (s) => {
     }
 };
 
-const plantUmlServerUrl = content => `https://www.plantuml.com/plantuml/svg/0/${urlTextFrom(content)}`;
+const plantUmlServerUrl = (content, options) => `${options.SERVER_BASE_ADDRESS}svg/0/${urlTextFrom(content)}`;
 
 const clearConsole = () => {
     process.stdout.write('\x1b[2J');


### PR DESCRIPTION
Addition of the possibility of including diagrams at an arbitrary position via the use of markdown syntax !\[](**_**_diagram_**.puml**). 

Fixes #21