### PR TITLE
Support for setting PlantUML Server URL

### DIFF
--- a/build.js
+++ b/build.js
@@ -165,7 +165,7 @@ const generateCompleteMD = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(options.PLANTUML_SERVER_URL, options.DIAGRAM_FORMAT, pumlFile.content);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -231,7 +231,7 @@ const generateCompletePDF = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(options.PLANTUML_SERVER_URL, options.DIAGRAM_FORMAT, pumlFile.content);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
 
@@ -362,7 +362,7 @@ const generateMD = async (tree, options, onProgress) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(options.PLANTUML_SERVER_URL, options.DIAGRAM_FORMAT, pumlFile.content);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;
@@ -423,7 +423,7 @@ const generatePDF = async (tree, options, onProgress) => {
                 MD += '\n\n';
                 let diagramUrl = encodeURIPath(path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`);
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(options.PLANTUML_SERVER_URL, options.DIAGRAM_FORMAT, pumlFile.content);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
 
@@ -523,7 +523,7 @@ const generateWebMD = async (tree, options) => {
                     path.parse(pumlFile.dir).name + `.${options.DIAGRAM_FORMAT}`
                 ));
                 if (!options.GENERATE_LOCAL_IMAGES)
-                    diagramUrl = plantUmlServerUrl(pumlFile.content);
+                    diagramUrl = plantUmlServerUrl(options.PLANTUML_SERVER_URL, options.DIAGRAM_FORMAT, pumlFile.content);
 
                 let diagramImage = `![diagram](${diagramUrl})`;
                 let diagramLink = `[Go to ${path.parse(pumlFile.dir).name} diagram](${diagramUrl})`;

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -250,6 +250,28 @@ module.exports = async (currentConfiguration, conf, program) => {
         }
     }
 
+    if (!currentConfiguration.PLANTUML_SERVER_URL || program.config) {
+        responses = await inquirer.prompt({
+            type: 'input',
+            name: 'plantumlServerUrl',
+            message: 'PlantUML Server URL',
+            default: currentConfiguration.PLANTUML_SERVER_URL || 'https://www.plantuml.com/plantuml',
+            validate: validate(joi.string().trim().optional())
+        });
+        conf.set('plantumlServerUrl', responses.plantumlServerUrl)
+    }
+
+    if (!currentConfiguration.DIAGRAM_FORMAT || program.config) {
+        responses = await inquirer.prompt({
+            type: 'input',
+            name: 'diagramFormat',
+            message: 'Diagram Image Format',
+            default: currentConfiguration.DIAGRAM_FORMAT || 'svg',
+            validate: validate(joi.string().trim().optional())
+        });
+        conf.set('diagramFormat', responses.diagramFormat)
+    }    
+
     if (!currentConfiguration.CHARSET || program.config) {
         responses = await inquirer.prompt({
             type: 'input',

--- a/cli.js
+++ b/cli.js
@@ -48,9 +48,10 @@ const getOptions = conf => {
         CHARSET: conf.get('charset'),
         WEB_PORT: conf.get('webPort'),
         HAS_RUN: conf.get('hasRun'),
+        PLANTUML_SERVER_URL: conf.get('plantumlServerUrl'),
+        DIAGRAM_FORMAT: conf.get('diagramFormat'),
         MD_FILE_NAME: 'README',
-        WEB_FILE_NAME: 'HOME',
-        DIAGRAM_FORMAT: 'svg'
+        WEB_FILE_NAME: 'HOME'
     }
 };
 

--- a/utils.js
+++ b/utils.js
@@ -116,7 +116,7 @@ const urlTextFrom = (s) => {
     }
 };
 
-const plantUmlServerUrl = content => `https://www.plantuml.com/plantuml/svg/0/${urlTextFrom(content)}`;
+const plantUmlServerUrl = (baseURL, imageFormat, content) => `${baseURL}/${imageFormat}/0/${urlTextFrom(content)}`;
 
 const clearConsole = () => {
     process.stdout.write('\x1b[2J');


### PR DESCRIPTION
Adds support for `plantumlServerUrl` defaulting to `https://www.plantuml.com/plantuml` so
that a private PlantUML server can be configured.

Also enables configuring the image format, defaulting to `svg`.