### PR TITLE
Feature Request 55 - Partial build (image generation)

### DIFF
--- a/build.js
+++ b/build.js
@@ -806,7 +806,7 @@ const build = async (options) => {
     }
 
     // Remove image backup folder
-    await fsextra.removeSync(options.DIST_FOLDER + '_bk');
+    await fsextra.removeSync(bkFolderName);
 
     console.log(chalk.green(`built in ${(new Date() - start_date) / 1000} seconds`));
 };

--- a/build.js
+++ b/build.js
@@ -6,8 +6,10 @@ const path = require('path');
 const fsextra = require('fs-extra');
 let docsifyTemplate = require('./docsify.template.js');
 const markdownpdf = require('md-to-pdf').mdToPdf;
-
 const http = require('http');
+
+const PUML_CHECKSUM_FILE = '_checksums.json';
+const DIST_BACKUP_FOLDER_SUFFIX = '_bk';
 
 const {
     encodeURIPath,
@@ -17,6 +19,7 @@ const {
     plantUmlServerUrl,
     plantumlVersions
 } = require('./utils.js');
+const { date } = require('joi');
 
 const getMime = (format) => {
     if (format == 'svg') return `image/svg+xml`;
@@ -126,43 +129,85 @@ const generateTree = async (dir, options) => {
 };
 
 const generateImages = async (tree, options, onImageGenerated) => {
+    let oldChecksums = [];
+    let newChecksums = [];
+    const bkFolderName = options.DIST_FOLDER + DIST_BACKUP_FOLDER_SUFFIX;
+
+    // Get the old checksums (from last run) of all PUML-files
+    if (await fs.existsSync(PUML_CHECKSUM_FILE)) {
+        var fileContent = await readFile(PUML_CHECKSUM_FILE);
+        try{
+            oldChecksums = JSON.parse('' + fileContent);
+        }catch{
+            oldChecksums = [];
+            await fs.unlinkSync(PUML_CHECKSUM_FILE);
+        }
+    }
+    
     let totalImages = 0;
     let processedImages = 0;
+
+    let ver = plantumlVersions.find((v) => v.version === options.PLANTUML_VERSION);
+    if (options.PLANTUML_VERSION === 'latest') ver = plantumlVersions.find((v) => v.isLatest);
+    if (!ver) throw new Error(`PlantUML version ${options.PLANTUML_VERSION} not supported`);
+
+    process.env.PLANTUML_HOME = path.join(__dirname, 'vendor', ver.jar);
+    const plantuml = require('node-plantuml');
+    const crypto = require('crypto');
 
     for (const item of tree) {
         totalImages += item.pumlFiles.length;
     }
+
     for (const item of tree) {
         for (const pumlFile of item.pumlFiles) {
-            //write diagram as image
-            let stream = fs.createWriteStream(
-                path.join(
-                    options.DIST_FOLDER,
-                    item.dir.replace(options.ROOT_FOLDER, ''),
-                    `${path.parse(pumlFile.dir).name}.${pumlFile.isDitaa ? 'png' : options.DIAGRAM_FORMAT}`
-                )
+            // Calculate hash of current puml content
+            let cksum = crypto
+                .createHash('sha256')
+                .update('' + pumlFile.content || '', 'utf-8')
+                .digest('hex');
+
+            // path to backup image file    
+            let bkFilePath = path.join(
+                bkFolderName,
+                item.dir.replace(options.ROOT_FOLDER, ''),
+                `${path.parse(pumlFile.dir).name}.${pumlFile.isDitaa ? 'png' : options.DIAGRAM_FORMAT}`
             );
 
-            let ver = plantumlVersions.find((v) => v.version === options.PLANTUML_VERSION);
-            if (options.PLANTUML_VERSION === 'latest') ver = plantumlVersions.find((v) => v.isLatest);
-            if (!ver) throw new Error(`PlantUML version ${options.PLANTUML_VERSION} not supported`);
+            // path to image in dist folder
+            let filePath = path.join(
+                options.DIST_FOLDER,
+                item.dir.replace(options.ROOT_FOLDER, ''),
+                `${path.parse(pumlFile.dir).name}.${pumlFile.isDitaa ? 'png' : options.DIAGRAM_FORMAT}`
+                );
 
-            process.env.PLANTUML_HOME = path.join(__dirname, 'vendor', ver.jar);
-            const plantuml = require('node-plantuml');
+            // if checksum exists (PUML untouched) and file/image exists - copy image back from backup folder
+            if (oldChecksums.find((x) => x === cksum) && (await fs.existsSync(bkFilePath))) {
+                await fsextra.copyFileSync(bkFilePath, filePath);
+            } else {
+                //write diagram as image
+                let stream = fs.createWriteStream(filePath);
+                
+                plantuml
+                    .generate(path.join(item.dir, pumlFile.dir), {
+                        format: pumlFile.isDitaa ? 'png' : options.DIAGRAM_FORMAT,
+                        charset: options.CHARSET,
+                        include: item.dir
+                    })
+                    .out.pipe(stream);
 
-            plantuml
-                .generate(path.join(item.dir, pumlFile.dir), {
-                    format: pumlFile.isDitaa ? 'png' : options.DIAGRAM_FORMAT,
-                    charset: options.CHARSET,
-                    include: item.dir
-                })
-                .out.pipe(stream);
-
-            await new Promise((resolve) => stream.on('finish', resolve));
+                await new Promise((resolve) => stream.on('finish', resolve));
+            }
             processedImages++;
             if (onImageGenerated) onImageGenerated(processedImages, totalImages);
+
+            // Add puml checksum
+            newChecksums.push(cksum);
         }
     }
+
+    // store all puml checksums to json
+    await fs.writeFileSync(PUML_CHECKSUM_FILE, JSON.stringify(newChecksums));
 };
 
 const compileDocument = async (md, item, options, getDiagram) => {
@@ -708,9 +753,18 @@ const generateWebMD = async (tree, options) => {
 
 const build = async (options) => {
     let start_date = new Date();
+    const bkFolderName = options.DIST_FOLDER + DIST_BACKUP_FOLDER_SUFFIX;
 
-    //clear dist directory
-    await fsextra.emptyDir(options.DIST_FOLDER);
+    // Generating local images, remove old backup image folder, rename current dist folder to new backup
+    if (options.GENERATE_LOCAL_IMAGES) {
+        await fsextra.removeSync(bkFolderName);
+        if (await fsextra.existsSync(options.DIST_FOLDER)) {
+            await fsextra.rename(options.DIST_FOLDER, bkFolderName);
+        }
+    } else {
+        //clear dist directory
+        await fsextra.emptyDir(options.DIST_FOLDER);
+    }
     await makeDirectory(path.join(options.DIST_FOLDER));
 
     //actual build
@@ -750,6 +804,9 @@ const build = async (options) => {
         });
         console.log('');
     }
+
+    // Remove image backup folder
+    await fsextra.removeSync(options.DIST_FOLDER + '_bk');
 
     console.log(chalk.green(`built in ${(new Date() - start_date) / 1000} seconds`));
 };


### PR DESCRIPTION
Solution that will only regenerate images for updated PUML files - #55 
This will only act when doing local images generation

- It will generate a checksum of all PUML files during a run
- If the checksum is same for the PUML (and image exists) it will copy back image from a backup folder
- If the checksum is not the same it will regenerate the image
- To enhance performance the DIST folder is renamed to backup folder (instead of copy everything)
- All checksums will be saved in root of the project (_checksums.json). If unable to read it a full generation will take place.

Also moved some part out of the inner for loop, because it will never change during a run and no need to re-evaluate

For my current project it takes about 35s to generate a site with local images.
On update it takes about 2-4s depending on complexity of PUML diagram.