### PR TITLE
Script tag execution and openapi rendering

### DIFF
--- a/build.js
+++ b/build.js
@@ -731,7 +731,8 @@ const generateWebMD = async (tree, options) => {
                 },
                 stylesheet: options.WEB_THEME,
                 alias: { '/.*/_sidebar.md': '/_sidebar.md' },
-                supportSearch: options.SUPPORT_SEARCH
+                supportSearch: options.SUPPORT_SEARCH,
+                executeScript: options.EXECUTE_SCRIPT
             })
         )
     );

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -197,6 +197,17 @@ module.exports = async (currentConfiguration, conf, program) => {
             conf.set('repoUrl', webOptions.repoUrl);
 
             webOptions = await inquirer.prompt({
+                type: 'confirm',
+                name: 'executeScript',
+                message: 'Support script execution and OpenAPI rendering?',
+                default: 
+                    currentConfiguration.executeScript === undefined
+                    ? false
+                    : currentConfiguration.executeScript
+            });
+            conf.set('executeScript', webOptions.executeScript);
+
+            webOptions = await inquirer.prompt({
                 type: 'input',
                 name: 'docsifyTemplate',
                 message: 'Path to a specific Docsify template?',

--- a/cli.js
+++ b/cli.js
@@ -52,6 +52,7 @@ const getOptions = (conf) => {
         MD_FILE_NAME: 'README',
         WEB_FILE_NAME: 'HOME',
         SUPPORT_SEARCH: conf.get('supportSearch'),
+        EXECUTE_SCRIPT: conf.get('executeScript'),
         EXCLUDE_OTHER_FILES: conf.get('excludeOtherFiles')
     };
 };

--- a/docsify.template.js
+++ b/docsify.template.js
@@ -35,6 +35,10 @@ module.exports = (options) => {
             !!options.supportSearch &&
             `<script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>`
         }
+        ${
+            !!options.executeScript &&
+            `<script src="//unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>`
+        }
     </body>
     
     </html>`;

--- a/template/src/1 Internet Banking System/API Specs/openapi.md
+++ b/template/src/1 Internet Banking System/API Specs/openapi.md
@@ -1,0 +1,25 @@
+
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta
+    name="description"
+    content="SwaggerIU"
+  />
+  <title>SwaggerUI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script>
+  window.onload = () => {
+    window.ui = SwaggerUIBundle({
+      url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+      dom_id: '#swagger-ui',
+    });
+  };
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
closes #61 

Supports `script ` tag execution in MD file

Supports Swagger UI for openapi specs loading using html and script tag in MD file as below

```
<html lang="en">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <meta
    name="description"
    content="SwaggerIU"
  />
  <title>SwaggerUI</title>
  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css" />
</head>
<body>
<div id="swagger-ui"></div>
<script>
  window.onload = () => {
    window.ui = SwaggerUIBundle({
      url: 'https://petstore3.swagger.io/api/v3/openapi.json',
      dom_id: '#swagger-ui',
    });
  };
</script>
</body>
</html>
```

![image](https://user-images.githubusercontent.com/3084986/164234909-af8ca34e-55e6-420a-9fd5-6818b048aaea.png)
