### PR TITLE
Checksums custom path

### DIFF
--- a/build.js
+++ b/build.js
@@ -770,7 +770,7 @@ const build = async (options, conf) => {
         console.log(chalk.blue('generating images'));
         checkums_conf = conf
         if (options.CHECKSUMS_FILE !== undefined) {
-            console.log(options.CHECKSUMS_FILE)
+            // console.log(options.CHECKSUMS_FILE)
             checkums_conf = new Configstore(
                 process.cwd().split(path.sep).splice(1).join('_'),
                 {},

--- a/build.js
+++ b/build.js
@@ -7,6 +7,7 @@ const fsextra = require('fs-extra');
 let docsifyTemplate = require('./docsify.template.js');
 const markdownpdf = require('md-to-pdf').mdToPdf;
 const http = require('http');
+const Configstore = require('configstore');
 
 const DIST_BACKUP_FOLDER_SUFFIX = '_bk';
 
@@ -767,13 +768,22 @@ const build = async (options, conf) => {
     console.log(chalk.blue(`parsed ${tree.length} folders`));
     if (options.GENERATE_LOCAL_IMAGES) {
         console.log(chalk.blue('generating images'));
+        checkums_conf = conf
+        if (options.CHECKSUMS_FILE !== undefined) {
+            console.log(options.CHECKSUMS_FILE)
+            checkums_conf = new Configstore(
+                process.cwd().split(path.sep).splice(1).join('_'),
+                {},
+                { configPath: path.join(process.cwd(), options.CHECKSUMS_FILE) }
+            );
+        }
         await generateImages(
             tree,
             options,
             (count, total) => {
                 process.stdout.write(`processed ${count}/${total} images\r`);
             },
-            conf
+            checkums_conf
         );
         console.log('');
     }

--- a/cli.js
+++ b/cli.js
@@ -30,6 +30,7 @@ const getOptions = (conf) => {
         GENERATE_COMPLETE_MD_FILE: conf.get('generateCompleteMD'),
         GENERATE_COMPLETE_PDF_FILE: conf.get('generateCompletePDF'),
         GENERATE_LOCAL_IMAGES: conf.get('generateLocalImages'),
+        CHECKSUMS_FILE: conf.get('checksumsFile'),
         EMBED_DIAGRAM: conf.get('embedDiagram'),
         ROOT_FOLDER: conf.get('rootFolder'),
         DIST_FOLDER: conf.get('distFolder'),


### PR DESCRIPTION
fix: store image checksums outside .c4builder config file. This way .c4builder config can remain immutable and can be easely tracked in version control systems

Fixes #68 