### PR TITLE
feat(web): add the ability to exclude folder of the sidebar

### DIFF
--- a/build.js
+++ b/build.js
@@ -640,11 +640,25 @@ const generateWebMD = async (tree, options) => {
     let filePromises = [];
     let docsifySideBar = '';
 
+    const isExcluded = (dir) => {
+        if (!Array.isArray(options.EXCLUDE_SIDEBAR_FOLDER_BY_PATH)) return false;
+
+        return options.EXCLUDE_SIDEBAR_FOLDER_BY_PATH.find((pathToExclude) => {
+            const isString = typeof pathToExclude === 'string';
+
+            if (isString) return dir.startsWith(pathToExclude);
+
+            return false;
+        });
+    };
+
     for (const item of tree) {
         //sidebar
-        docsifySideBar += `${'  '.repeat(item.level - 1)}* [${item.name}](${encodeURIPath(
-            path.join(...path.join(item.dir).split(path.sep).splice(1), options.WEB_FILE_NAME)
-        )})\n`;
+        if (!isExcluded(item.dir)) {
+            docsifySideBar += `${'  '.repeat(item.level - 1)}* [${item.name}](${encodeURIPath(
+                path.join(...path.join(item.dir).split(path.sep).splice(1), options.WEB_FILE_NAME)
+            )})\n`;
+        }
         let name = getFolderName(item.dir, options.ROOT_FOLDER, options.HOMEPAGE_NAME);
 
         //title

--- a/cli.js
+++ b/cli.js
@@ -42,6 +42,7 @@ const getOptions = (conf) => {
         INCLUDE_BREADCRUMBS: conf.get('includeBreadcrumbs'),
         INCLUDE_TABLE_OF_CONTENTS: conf.get('includeTableOfContents'),
         INCLUDE_LINK_TO_DIAGRAM: conf.get('includeLinkToDiagram'),
+        EXCLUDE_SIDEBAR_FOLDER_BY_PATH: conf.get('excludeSidebarFolderByPath'),
         PDF_CSS: conf.get('pdfCss') || path.join(__dirname, 'pdf.css'),
         DIAGRAMS_ON_TOP: conf.get('diagramsOnTop'),
         CHARSET: conf.get('charset'),

--- a/cli.list.js
+++ b/cli.list.js
@@ -108,6 +108,11 @@ Replace diagrams with a link: ${
             ? chalk.green(currentConfiguration.INCLUDE_LINK_TO_DIAGRAM)
             : chalk.red('not set')
     }
+Exclude sidebar folder by path: ${
+        Array.isArray(currentConfiguration.EXCLUDE_SIDEBAR_FOLDER_BY_PATH)
+            ? chalk.green(currentConfiguration.EXCLUDE_SIDEBAR_FOLDER_BY_PATH)
+            : chalk.red('not is an array or not set')
+    }
 Place diagrams before text: ${
         currentConfiguration.DIAGRAMS_ON_TOP !== undefined
             ? chalk.green(currentConfiguration.DIAGRAMS_ON_TOP)
@@ -129,9 +134,9 @@ Charset: ${
             : chalk.red('not set')
     }
 Exclude other files: ${
-    currentConfiguration.EXCLUDE_OTHER_FILES !== undefined
-        ? chalk.green(currentConfiguration.EXCLUDE_OTHER_FILES)
-        : chalk.red('not set')
+        currentConfiguration.EXCLUDE_OTHER_FILES !== undefined
+            ? chalk.green(currentConfiguration.EXCLUDE_OTHER_FILES)
+            : chalk.red('not set')
     }
 `);
     return;


### PR DESCRIPTION
## Why
In some situations, I need to create static files to customize the page, but it should not appear in the sidebar.

## What
In the build process is checked if `dist` starts with any value of the array options (excludeSidebarFolderByPath), if true, the folder is ignored to show no sidebar, otherwise, will be rendered. 

## How to use

Just add a new option in `.c4builder`:

```json
{
  "excludeSidebarFolderByPath": [
    "src/configs"
  ]
}

```

## Example

My project:
![image](https://github.com/adrianvlupu/C4-Builder/assets/32512776/03e00dc6-a923-43cc-bf71-b85f152bf5da)

Output without this feature:
![image](https://github.com/adrianvlupu/C4-Builder/assets/32512776/054e7b0f-1ed6-4f1c-93cc-4edd3950db2f)

Output with this feature:
![image](https://github.com/adrianvlupu/C4-Builder/assets/32512776/22f2a09f-aaba-4184-a696-1f2813fd589d)

