### PR TITLE
feat(web): add the ability to use the original file name

### DIFF
--- a/build.js
+++ b/build.js
@@ -640,11 +640,14 @@ const generateWebMD = async (tree, options) => {
     let filePromises = [];
     let docsifySideBar = '';
 
+    const getWebFileName = (originalFileName) => options.WEB_FILE_NAME || originalFileName;
+
     for (const item of tree) {
         //sidebar
         docsifySideBar += `${'  '.repeat(item.level - 1)}* [${item.name}](${encodeURIPath(
-            path.join(...path.join(item.dir).split(path.sep).splice(1), options.WEB_FILE_NAME)
+            path.join(...path.join(item.dir).split(path.sep).splice(1), getWebFileName(item.name))
         )})\n`;
+
         let name = getFolderName(item.dir, options.ROOT_FOLDER, options.HOMEPAGE_NAME);
 
         //title
@@ -705,7 +708,7 @@ const generateWebMD = async (tree, options) => {
                 path.join(
                     options.DIST_FOLDER,
                     item.dir.replace(options.ROOT_FOLDER, ''),
-                    `${options.WEB_FILE_NAME}.md`
+                    `${getWebFileName(item.name)}.md`
                 ),
                 MD
             )
@@ -716,6 +719,8 @@ const generateWebMD = async (tree, options) => {
         docsifyTemplate = require(path.join(process.cwd(), options.DOCSIFY_TEMPLATE));
     }
 
+    const getRootName = () => tree.find((item) => !item.parent);
+
     //docsify homepage
     filePromises.push(
         writeFile(
@@ -725,7 +730,7 @@ const generateWebMD = async (tree, options) => {
                 repo: options.REPO_NAME,
                 loadSidebar: true,
                 auto2top: true,
-                homepage: `${options.WEB_FILE_NAME}.md`,
+                homepage: `${options.WEB_FILE_NAME || getRootName().name}.md`,
                 plantuml: {
                     skin: 'classic'
                 },

--- a/cli.js
+++ b/cli.js
@@ -50,7 +50,7 @@ const getOptions = (conf) => {
         PLANTUML_SERVER_URL: conf.get('plantumlServerUrl'),
         DIAGRAM_FORMAT: conf.get('diagramFormat'),
         MD_FILE_NAME: 'README',
-        WEB_FILE_NAME: 'HOME',
+        WEB_FILE_NAME: conf.get('webFileName'),
         SUPPORT_SEARCH: conf.get('supportSearch'),
         EXCLUDE_OTHER_FILES: conf.get('excludeOtherFiles')
     };

--- a/cli.list.js
+++ b/cli.list.js
@@ -128,10 +128,15 @@ Charset: ${
             ? chalk.green(currentConfiguration.CHARSET)
             : chalk.red('not set')
     }
+Web file name: ${
+        currentConfiguration.WEB_FILE_NAME !== undefined
+            ? chalk.green(currentConfiguration.WEB_FILE_NAME)
+            : chalk.red('not set')
+    }
 Exclude other files: ${
-    currentConfiguration.EXCLUDE_OTHER_FILES !== undefined
-        ? chalk.green(currentConfiguration.EXCLUDE_OTHER_FILES)
-        : chalk.red('not set')
+        currentConfiguration.EXCLUDE_OTHER_FILES !== undefined
+            ? chalk.green(currentConfiguration.EXCLUDE_OTHER_FILES)
+            : chalk.red('not set')
     }
 `);
     return;


### PR DESCRIPTION
## Why
This feature allows the use of the [docsify-edit-on-github](https://github.com/njleonzhang/docsify-edit-on-github) plugin which needs the original file name in the path.

## What
Added `WEB_FILE_NAME` as an option in the configuration.

## How to use

If you add `webFileName` to `.c4builder`, each `.md` will be named exactly the same as the defined value. The default value is `HOME`, [see](https://github.com/adrianvlupu/C4-Builder/blob/e24d4c411e0a6d7886a49d000d91836c7d58e713/cli.js#L53).

This feature ability to use the original file name and remove the default value (HOME).

![NOTE](https://via.placeholder.com/10/ff0000/ff0000) NOTE: To maintain compatibility with previous versions of links, add a new option in `.c4builder`:

```json
{
  "webFileName": "HOME"
}

```

## Example

Without this feature or with the `webFileName` option equal to "HOME":

https://github.com/adrianvlupu/C4-Builder/assets/32512776/b9bb4a99-f281-4589-8387-a6cbd80c7f2f

With this feature and `webFileName` not defined or empty:

https://github.com/adrianvlupu/C4-Builder/assets/32512776/83479598-af77-4172-823b-52d608ddb0c0

