### PR TITLE
'> c4builder site --watch' - fix for crash if files are modified.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -137,7 +137,7 @@ module.exports = async () => {
                 await build(options, conf);
                 while (attemptedWatchBuild) {
                     attemptedWatchBuild = false;
-                    await build(options);
+                    await build(options, conf);
                 }
                 isBuilding = false;
             });


### PR DESCRIPTION
Found an annoying issue where modifying files in the src project tends to crash the running localhost:3000 site.

## Replicating the bug

In an existing C4Builder project, Run a local site with watch enabled

> c4builder site --watch

Once your site is up and running, change one of the following inside your ./src folder:-
- A folder Name
- A .md file name
- A .puml file name
- An image file [.png,.jpg,etc]

You should encounter the following error:-

	C:\Tools\node\node-v16.15.0-win-x64\node_modules\c4builder\build.js:135
	    let oldChecksums = conf.get('checksums') || [];
	                            ^
	
	TypeError: Cannot read properties of undefined (reading 'get')
	    at generateImages (C:\Tools\node\node-v16.15.0-win-x64\node_modules\c4builder\build.js:135:29)
	    at build (C:\Tools\node\node-v16.15.0-win-x64\node_modules\c4builder\build.js:770:15)
	    at async Watcher.<anonymous> (C:\Tools\node\node-v16.15.0-win-x64\node_modules\c4builder\cli.js:140:21)
	    
This seems to be due to conf not being passed to build() method at line:140 in ./cli.js.

Passing in conf appears to fix this problem.

Tested on:-
- MacOS 13 (Silicon)
- Windows 10